### PR TITLE
Part of the fix for Kitura issue 417

### DIFF
--- a/Sources/KituraSys/Group.swift
+++ b/Sources/KituraSys/Group.swift
@@ -1,0 +1,64 @@
+/**
+ * Copyright IBM Corporation 2015
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Dispatch
+
+// MARK: Group
+
+public class Group {
+    
+    public init() {}
+    
+    #if os(Linux)
+        private let osGroup = dispatch_group_create()
+    #else
+        private let osGroup = dispatch_group_create()!
+    #endif
+    
+    ///
+    /// Run a block asynchronously
+    ///
+    /// - Parameter block: a closure () -> Void
+    ///
+    public func enqueueAsynchronously(on queue: Queue, block: () -> Void) {
+        dispatch_group_async(osGroup, queue.osQueue, block)
+    }
+    
+    ///
+    /// Wait synchronously for asynchronous blocks to complete
+    ///
+    public func wait(for timeout: GroupTimeout) {
+        let osTimeout: dispatch_time_t
+        switch(timeout) {
+        case .ever:
+            osTimeout = DISPATCH_TIME_FOREVER
+        case .seconds(let seconds):
+            osTimeout = dispatch_time(DISPATCH_TIME_NOW, seconds * Int64(NSEC_PER_SEC))
+        case .milliSeconds(let milliSeconds):
+            osTimeout = dispatch_time(DISPATCH_TIME_NOW, milliSeconds * Int64(NSEC_PER_USEC))
+        case .nanoSeconds(let nanoSeconds):
+            osTimeout = dispatch_time(DISPATCH_TIME_NOW, nanoSeconds)
+        }
+        dispatch_group_wait(osGroup, osTimeout)
+    }
+}
+
+///
+/// Timeout values
+///
+public enum GroupTimeout {
+    case ever, seconds(Int64), milliSeconds(Int64), nanoSeconds(Int64)
+}

--- a/Sources/KituraSys/Queue.swift
+++ b/Sources/KituraSys/Queue.swift
@@ -28,7 +28,7 @@ public class Queue {
     ///
     /// Handle to the libDispatch queue
     ///
-    private let osQueue: dispatch_queue_t
+    internal let osQueue: dispatch_queue_t
 
 
     ///


### PR DESCRIPTION
Changes to KituraSys as part of he overall fix for issue IBM-Swift/Kitura#417
## Description
<!--- Describe your changes in detail -->
Added a Group class to model dispatch_group_t.  Blocks can now be executed asynchronously on a queue within the scope of a group. A group can be waited on until all blocks enqueued end.

## Motivation and Context
On Linux processes running Kitura used to get marked as defunct. This prevented:
  1. The use of LLDB to debug
  2. Getting core files when Kitura crashed
  3. Tools like top didn't report useful information

This was apparently due to the way dispatch_main is implemented on Linux.

This is issue IBM-Swift/Kitura#417

## How Has This Been Tested?
Tested as part of the performance test work, ran Kitura under lldb, and have successfully gotten core files when Kitura processes crash.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.

