### PR TITLE
IBM-Swift/Kitura#435 Made the osQueue field publically readable

### DIFF
--- a/Sources/KituraSys/Queue.swift
+++ b/Sources/KituraSys/Queue.swift
@@ -28,7 +28,7 @@ public class Queue {
     ///
     /// Handle to the libDispatch queue
     ///
-    internal let osQueue: dispatch_queue_t
+    public let osQueue: dispatch_queue_t
 
 
     ///


### PR DESCRIPTION
## Description
Made the osQueue field of the Queue class accessible outside of the Kitura-sys repository

## Motivation and Context
The implementation of keep alive and asynchronous socket I/O using dispatch_io (on OSX for now) needs a queue. I am using the ClientHandler queue of HTTPServer and need access to the osQueue element from outside the Kitura-sys repository

## How Has This Been Tested?
I have run various stress tests using this code.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

