### PR TITLE
Simplifying the travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,4 @@ before_install:
   - cd Kitura-Build && git checkout master && cd $TRAVIS_BUILD_DIR
 
 script:
-  - echo ">> Let's build and test the '$TRAVIS_BRANCH' branch for Kitura-sys."
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./Kitura-Build/run_kitura_ubuntu_container.sh $TRAVIS_BRANCH $TRAVIS_BUILD_DIR Kitura; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./Kitura-Build/build_kitura_package.sh ; fi
-  - echo ">> Build and tests completed. See above for status."
+  - ./Kitura-Build/script_travis.sh $TRAVIS_OS_NAME $TRAVIS_BRANCH $TRAVIS_BUILD_DIR Kitura-sys 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To simplify all .travis.yml file to reduce code duplication

## Motivation and Context
We created a script file in the Kitura-Build repo to be called instead of copying the same 4 lines to multiple repo's travis.yml files

## How Has This Been Tested?
Ran the code through Travis CI which builds Kitura-Build on linux and mac

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.